### PR TITLE
[Fix] Vercel 환경변수 영구 설정으로 Callback 에러 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,12 +33,49 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
-      - name: Deploy to Vercel (Production)
+      - name: Set Vercel Environment Variables
         run: |
-          vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }} \
-            -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
-            -e DIRECT_URL="${{ secrets.DIRECT_URL }}" \
-            -e NEXTAUTH_SECRET="${{ secrets.NEXTAUTH_SECRET }}" \
-            -e NEXTAUTH_URL="${{ secrets.NEXTAUTH_URL }}" \
-            -e KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}" \
-            -e KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}"
+          # Function to upsert environment variable
+          upsert_env() {
+            local key=$1
+            local value=$2
+
+            # Check if env var exists
+            existing=$(curl -s -X GET \
+              "https://api.vercel.com/v9/projects/${{ secrets.VERCEL_PROJECT_ID }}/env?key=$key" \
+              -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" \
+              -H "Content-Type: application/json")
+
+            env_id=$(echo "$existing" | jq -r '.envs[0].id // empty')
+
+            if [ -n "$env_id" ]; then
+              # Update existing
+              curl -s -X PATCH \
+                "https://api.vercel.com/v9/projects/${{ secrets.VERCEL_PROJECT_ID }}/env/$env_id" \
+                -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" \
+                -H "Content-Type: application/json" \
+                -d "{\"value\":\"$value\"}" > /dev/null
+              echo "Updated: $key"
+            else
+              # Create new
+              curl -s -X POST \
+                "https://api.vercel.com/v10/projects/${{ secrets.VERCEL_PROJECT_ID }}/env" \
+                -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" \
+                -H "Content-Type: application/json" \
+                -d "{\"key\":\"$key\",\"value\":\"$value\",\"target\":[\"production\"],\"type\":\"encrypted\"}" > /dev/null
+              echo "Created: $key"
+            fi
+          }
+
+          # Set all environment variables
+          upsert_env "DATABASE_URL" "${{ secrets.DATABASE_URL }}"
+          upsert_env "DIRECT_URL" "${{ secrets.DIRECT_URL }}"
+          upsert_env "NEXTAUTH_SECRET" "${{ secrets.NEXTAUTH_SECRET }}"
+          upsert_env "NEXTAUTH_URL" "${{ secrets.NEXTAUTH_URL }}"
+          upsert_env "KAKAO_CLIENT_ID" "${{ secrets.KAKAO_CLIENT_ID }}"
+          upsert_env "KAKAO_CLIENT_SECRET" "${{ secrets.KAKAO_CLIENT_SECRET }}"
+
+          echo "Environment variables configured successfully"
+
+      - name: Deploy to Vercel (Production)
+        run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## 관련 이슈
closes #5

## 문제 원인
`vercel deploy -e KEY=VALUE`는 해당 배포에만 환경변수를 적용하고, Vercel 프로젝트에 **영구 저장되지 않음**.
런타임에 환경변수가 없어서 NextAuth Callback 에러 발생.

## 변경 사항
- Vercel API를 통해 환경변수를 프로젝트에 영구 저장하도록 수정
- 배포 전 `upsert_env` 함수로 환경변수 설정 (존재하면 업데이트, 없으면 생성)
- 기존 `-e` 옵션 제거

## 설정되는 환경변수
- `DATABASE_URL`
- `DIRECT_URL`
- `NEXTAUTH_SECRET`
- `NEXTAUTH_URL`
- `KAKAO_CLIENT_ID`
- `KAKAO_CLIENT_SECRET`

## 테스트
- [x] 워크플로우 문법 검증
- [ ] 배포 후 환경변수 확인
- [ ] 카카오 로그인 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)