### PR TITLE
[Feature] 공공기관 채용정보 데이터 화면 표출 (#22)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -291,7 +291,7 @@ export default function Home() {
                   <span className="text-blue-500">✓</span> 전공 기반 맞춤 추천
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="text-blue-500">✓</span> 5개 사이트 통합 검색
+                  <span className="text-blue-500">✓</span> 공공기관 채용정보 연동
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="text-blue-500">✓</span> AI 학습으로 추천 개선

--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -87,10 +87,22 @@ export default function JobCard({ recommendation, onRatingChange, onFavoriteChan
               ? 'bg-blue-100 text-blue-700'
               : jobPosting.source === 'jobkorea'
               ? 'bg-green-100 text-green-700'
+              : jobPosting.source === 'recruitment'
+              ? 'bg-purple-100 text-purple-700'
+              : jobPosting.source === 'wanted'
+              ? 'bg-teal-100 text-teal-700'
+              : jobPosting.source === 'jumpit'
+              ? 'bg-orange-100 text-orange-700'
+              : jobPosting.source === 'incruit'
+              ? 'bg-rose-100 text-rose-700'
               : 'bg-gray-100 text-gray-600'
           }`}>
             {jobPosting.source === 'saramin' ? '사람인' :
              jobPosting.source === 'jobkorea' ? '잡코리아' :
+             jobPosting.source === 'recruitment' ? '공공기관' :
+             jobPosting.source === 'wanted' ? '원티드' :
+             jobPosting.source === 'jumpit' ? '점핏' :
+             jobPosting.source === 'incruit' ? '인크루트' :
              jobPosting.source}
           </span>
         </div>


### PR DESCRIPTION
## 관련 이슈
closes #22

## 변경 사항
- **JobCard 소스 배지**: `recruitment` → 보라색 "공공기관" 배지 추가
  - `wanted` → 틸색 "원티드", `jumpit` → 주황색 "점핏", `incruit` → 로즈색 "인크루트" 도 함께 매핑
- **로그인 화면 문구**: "5개 사이트 통합 검색" → "공공기관 채용정보 연동"

## 수정 파일
| 파일 | 변경 |
|------|------|
| `src/components/JobCard.tsx` | 소스 배지 색상/이름 매핑 추가 |
| `src/app/page.tsx` | 소개 문구 수정 |

## 테스트
- [x] 빌드 성공
- [x] 기존 소스(saramin, jobkorea) 배지 동작 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)