### PR TITLE
[Fix] 채용공고 화면 연동 개선 및 카카오 로그인 콜백 에러 수정 (#24)

### DIFF
--- a/.claude/commands/dashboard.md
+++ b/.claude/commands/dashboard.md
@@ -1,34 +1,9 @@
 # 개발 현황 대시보드
 
-에이전트들의 현재 작업 현황을 확인합니다.
-
-## 수행할 작업
-
-dashboard.sh 스크립트를 실행하여 현황을 확인하세요:
+`./dashboard.sh` 스크립트를 실행하여 개발 현황을 출력하세요.
 
 ```bash
-./dashboard.sh
+bash ./dashboard.sh
 ```
 
-또는 아래 명령어들을 개별 실행:
-
-### PM 에이전트 현황 (이슈)
-```bash
-gh issue list --repo gyuturn/cruit --state open
-```
-
-### 개발자 에이전트 현황 (브랜치)
-```bash
-git branch -a
-git status
-```
-
-### PR 현황
-```bash
-gh pr list --repo gyuturn/cruit --state open
-```
-
-### 배포 현황
-```bash
-git log main --oneline -5
-```
+실행 결과를 사용자에게 그대로 보여주세요.

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -20,6 +20,12 @@ if (missingEnvVars.length > 0) {
   );
 }
 
+// NEXTAUTH_URL 자동 감지 (Vercel 배포 시 VERCEL_URL 사용)
+if (!process.env.NEXTAUTH_URL && process.env.VERCEL_URL) {
+  process.env.NEXTAUTH_URL = `https://${process.env.VERCEL_URL}`;
+  console.log(`[NextAuth] NEXTAUTH_URL auto-detected: ${process.env.NEXTAUTH_URL}`);
+}
+
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
@@ -28,6 +34,7 @@ export const authOptions: NextAuthOptions = {
       clientSecret: process.env.KAKAO_CLIENT_SECRET ?? "",
     }),
   ],
+  secret: process.env.NEXTAUTH_SECRET,
   session: {
     strategy: "database",
     maxAge: 30 * 24 * 60 * 60, // 30일
@@ -39,6 +46,12 @@ export const authOptions: NextAuthOptions = {
         provider: account?.provider,
       });
       return true;
+    },
+    async redirect({ url, baseUrl }) {
+      // 콜백 URL 안전 처리 - 같은 도메인이면 허용, 아니면 홈으로
+      if (url.startsWith("/")) return `${baseUrl}${url}`;
+      if (new URL(url).origin === baseUrl) return url;
+      return baseUrl;
     },
     async session({ session, user }) {
       // 세션에 사용자 ID 추가
@@ -74,5 +87,5 @@ export const authOptions: NextAuthOptions = {
     signIn: "/auth/signin",
     error: "/auth/error",
   },
-  debug: true, // 프로덕션에서도 디버그 활성화
+  debug: process.env.NODE_ENV === "development",
 };


### PR DESCRIPTION
## 관련 이슈
closes #24

## 변경 사항

### 1. 채용공고 화면-DB 연동 개선 (`src/lib/crawler/index.ts`)
- `fetchJobsFromDb()`: 키워드 매칭 결과가 5건 미만일 때 **전체 활성 공고를 폴백 조회**
- 키워드 매칭된 공고를 우선 배치하고, 나머지 최신 공고를 추가하여 최대 100건 반환
- 공통 매핑 함수 `mapDbJobToJobPosting()` 추출로 코드 정리

### 2. 카카오 로그인 콜백 에러 수정 (`src/lib/auth/index.ts`)
- **NEXTAUTH_URL 자동 감지**: `NEXTAUTH_URL` 미설정 시 Vercel의 `VERCEL_URL`에서 자동 추론
- **redirect 콜백 추가**: 콜백 URL 안전 처리 (같은 도메인만 허용, 나머지는 홈으로 리다이렉트)
- **secret 명시적 설정**: `authOptions`에 `secret` 필드 직접 지정
- **debug 모드 제한**: 프로덕션에서 불필요한 디버그 로그 제거 (`NODE_ENV === "development"` 한정)

## 테스트
- [x] TypeScript 타입 체크 통과
- [x] API 데이터 수집 확인 (95건 DB 저장 완료)
- [x] 키워드 매칭 실패 시 전체 공고 폴백 로직 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)